### PR TITLE
Update Qualys_Infrascan_Webgui parser.py

### DIFF
--- a/dojo/tools/qualys_infrascan_webgui/parser.py
+++ b/dojo/tools/qualys_infrascan_webgui/parser.py
@@ -54,6 +54,8 @@ def issue_r(raw_row, vuln, scan_date):
 
     # FQDN
     issue_row['fqdn'] = raw_row.get('name')
+    if issue_row['fqdn'] == "No registered hostname":
+        issue_row['fqdn'] = False
 
     # Create Endpoint
     if issue_row['fqdn']:

--- a/dojo/unittests/scans/qualys_infrascan_webgui/qualys_infrascan_webgui_3.xml
+++ b/dojo/unittests/scans/qualys_infrascan_webgui/qualys_infrascan_webgui_3.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE SCAN SYSTEM "https://qualysapi.qg2.apps.qualys.eu/scan-1.dtd">
+<!-- Initializing Data -->
+<!-- Generating XML report -->
+<SCAN value="scan/1609253113.01100">
+
+<HEADER>
+  <KEY value="USERNAME">Username</KEY>
+  <KEY value="COMPANY"><![CDATA[Company Name]]></KEY>
+  <KEY value="DATE">2019-04-02T10:14:53Z</KEY>
+  <KEY value="TITLE"><![CDATA[Report Title]]></KEY>
+  <KEY value="TARGET"><![CDATA[10.1.10.1]]></KEY>
+  <KEY value="EXCLUDED_TARGET"><![CDATA[N/A]]></KEY>
+  <KEY value="DURATION">04:29:11</KEY>
+  <KEY value="SCAN_HOST">ScanHost</KEY>
+  <KEY value="NBHOST_ALIVE">1</KEY>
+  <KEY value="NBHOST_TOTAL">1</KEY>
+  <KEY value="REPORT_TYPE">On-demand</KEY>
+  <KEY value="OPTIONS"><![CDATA[Full TCP scan, Standard UDP port list, parallel ML scaling disabled for appliances, Load balancer detection OFF, Windows Authentication ON, Unix Authentication ON, Oracle Authentication ON, SNMP Authentication ON, Oracle Listener Authentication ON, VMware Authentication ON, DB2 Authentication ON, HTTP Authentication ON, MySQL Authentication ON, ICMP Host Discovery, Overall Performance: Custom, Hosts to Scan in Parallel - External Scanners: 5, Hosts to Scan in Parallel - Scanner Appliances: 3, Total Processes to Run in Parallel: 2, HTTP Processes to Run in Parallel: 2, Packet (Burst) Delay: Long, Intensity: Low]]></KEY>
+  <KEY value="STATUS">FINISHED</KEY>
+  <OPTION_PROFILE>
+    <OPTION_PROFILE_TITLE option_profile_default="0"><![CDATA[Option Profile]]></OPTION_PROFILE_TITLE>
+  </OPTION_PROFILE>
+</HEADER>
+
+<IP value="10.1.10.1" name="No registered hostname">
+  <OS><![CDATA[Linux 2.6]]></OS>
+  <VULNS>
+  </VULNS>
+</IP>
+</SCAN>
+<!-- CONFIDENTIAL AND PROPRIETARY INFORMATION. Qualys provides the QualysGuard Service "As Is," without any warranty of any kind. Qualys makes no warranty that the information contained in this report is complete or error-free. Copyright 2020, Qualys, Inc. //--> 


### PR DESCRIPTION
Catching "No registered hostname" as non-valid value for fqdn, falling back to IP address to be used for the endpoint; otherwise you get an endpoint called "No registered hostname" and findings are aggregated incorrectly.

Raw XML report extract example (actual public IP has been replaced with 127.0.0.1):

`<IP value="127.0.0.1" name="No registered hostname">`
`<OS><![CDATA[Linux 2.6]]></OS>`
`<INFOS>`
`<CAT value="Information gathering">`
`<INFO number="6" severity="1">`
`<TITLE><![CDATA[DNS Host Name]]></TITLE>`
`<LAST_UPDATE><![CDATA[2018-01-04T17:39:37Z]]></LAST_UPDATE>`
`<PCI_FLAG>0</PCI_FLAG>`
`<DIAGNOSIS><![CDATA[The fully qualified domain name of this host, if it was obtained from a DNS server, is displayed in the RESULT section.]]></DIAGNOSIS>`
`<CONSEQUENCE><![CDATA[N/A]]></CONSEQUENCE>`
`<SOLUTION><![CDATA[N/A]]></SOLUTION>`
`<RESULT format="table"><![CDATA[IP address Host name 127.0.0.1 No registered hostname]]></RESULT>`
`</INFO>`